### PR TITLE
Fix Poetry config deprecation

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,7 +18,7 @@ redis = "^6.2.0"
 httpx = "^0.28.1"
 uvicorn = { version = "^0.34.3", optional = true }
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^7.4"
 pytest-asyncio = "^0.21"
 alembic = "^1.11"


### PR DESCRIPTION
## Summary
- update `[tool.poetry.dev-dependencies]` to `[tool.poetry.group.dev.dependencies]`

## Testing
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_686a4cbe7e48832b808f4b43a53dc522