### PR TITLE
refactor(): remove delete-all-goals feature end-to-end

### DIFF
--- a/backend/src/crud/board.py
+++ b/backend/src/crud/board.py
@@ -126,17 +126,6 @@ async def delete_goal(db: AsyncSession, goal_id: int) -> bool:
     return True
 
 
-async def delete_all_goals(db: AsyncSession, board_id: int) -> None:
-    columns = await get_board_columns(db, board_id)
-    if not columns:
-        return
-    col_ids = [c.id for c in columns]
-    result = await db.execute(select(Card).where(Card.column_id.in_(col_ids)))
-    for card in result.scalars().all():
-        await db.delete(card)
-    await db.commit()
-
-
 async def delete_board(db: AsyncSession, board_id: int) -> bool:
     result = await db.execute(select(Board).where(Board.id == board_id))
     board = result.scalars().first()

--- a/backend/src/routers/boards.py
+++ b/backend/src/routers/boards.py
@@ -4,7 +4,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.crud.board import (
     create_board,
     create_goal,
-    delete_all_goals,
     delete_board,
     delete_goal,
     list_boards,
@@ -61,13 +60,6 @@ async def delete_goal_endpoint(goal_id: int, db: AsyncSession = Depends(get_db))
     deleted = await delete_goal(db, goal_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Goal not found")
-
-
-@router.delete("/boards/{board_id}/goals", status_code=204)
-async def delete_all_goals_endpoint(
-    board_id: int, db: AsyncSession = Depends(get_db)
-):
-    await delete_all_goals(db, board_id=board_id)
 
 
 @router.delete("/boards/{board_id}", status_code=204)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,7 +64,7 @@ lifeflow/
 
 **Рекомендация:**
 - Ввести переменную окружения Vite, например `VITE_API_URL`, и использовать `import.meta.env.VITE_API_URL || "http://localhost:8000"`.
-- Вынести запросы к API в отдельный модуль (например, `api/goals.ts`) с функциями `getGoals()`, `createGoal()`, `toggleGoal()`, `deleteAllGoals()` — так проще менять базовый URL и переиспользовать логику.
+- Вынести запросы к API в отдельный модуль (например, `api/goals.ts`) с функциями `getGoals()`, `createGoal()`, `updateGoal()`, `deleteGoal()` — так проще менять базовый URL и переиспользовать логику.
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,7 @@ export default function App() {
     localStorage.setItem("lifeflow-theme", theme);
   }, [theme]);
 
-  const { boards, selectedBoardId, goals, loading, saving, error, addGoal, editGoal, moveGoal, deleteGoal, deleteAll } =
+  const { selectedBoardId, goals, loading, saving, error, addGoal, editGoal, moveGoal, deleteGoal } =
     useBoard();
 
   return (
@@ -43,11 +43,6 @@ export default function App() {
         <Footer saving={saving} onAdd={addGoal} />
       )}
 
-      {boards.length > 0 && goals.length > 0 && (
-        <button type="button" className="app-delete-all" onClick={deleteAll}>
-          удалить все цели
-        </button>
-      )}
     </div>
   );
 }

--- a/frontend/src/api/boards.ts
+++ b/frontend/src/api/boards.ts
@@ -24,6 +24,3 @@ export const patchGoal = (
 
 export const removeGoal = (goalId: number) =>
   apiRequest<void>(`${API_BASE}/goals/${goalId}`, { method: "DELETE" });
-
-export const removeAllGoals = (boardId: number) =>
-  apiRequest<void>(`${API_BASE}/boards/${boardId}/goals`, { method: "DELETE" });

--- a/frontend/src/hooks/useBoard.ts
+++ b/frontend/src/hooks/useBoard.ts
@@ -4,7 +4,6 @@ import {
   listBoards,
   listGoals,
   patchGoal,
-  removeAllGoals,
   removeGoal,
 } from "../api/boards";
 import type { Board, Goal } from "../types";
@@ -96,17 +95,6 @@ export function useBoard() {
     }
   };
 
-  const deleteAll = async () => {
-    if (selectedBoardId == null) return;
-    setError(null);
-    try {
-      await removeAllGoals(selectedBoardId);
-      setGoals([]);
-    } catch (e) {
-      setError(toMessage(e));
-    }
-  };
-
   return {
     boards,
     selectedBoardId,
@@ -118,6 +106,5 @@ export function useBoard() {
     editGoal,
     moveGoal,
     deleteGoal,
-    deleteAll,
   };
 }


### PR DESCRIPTION
Drop the unused bulk goal deletion flow from frontend UI/state/api and remove its backend endpoint/CRUD logic to keep the product surface minimal and focused on per-goal actions.

Made-with: Cursor