### PR TITLE
feat(goals): add immutable goal lifetime and due-date UX

### DIFF
--- a/backend/alembic/versions/d7c3b2a190fe_add_cards_due_at.py
+++ b/backend/alembic/versions/d7c3b2a190fe_add_cards_due_at.py
@@ -1,0 +1,29 @@
+"""add cards due_at (goal lifetime end)
+
+Revision ID: d7c3b2a190fe
+Revises: b21f8d3e9a0c
+Create Date: 2026-04-03
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d7c3b2a190fe"
+down_revision: Union[str, Sequence[str], None] = "b21f8d3e9a0c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "cards",
+        sa.Column("due_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("cards", "due_at")

--- a/backend/src/crud/board.py
+++ b/backend/src/crud/board.py
@@ -1,3 +1,5 @@
+from datetime import date, datetime, timezone
+
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import selectinload
@@ -18,6 +20,23 @@ LEGACY_BOARD_TITLE_MAPPING = {
     "Долгосрочные цели (месяц и более)": "Долгосрочные",
 }
 LEGACY_SINGLE_BOARD_TITLE = "Моя доска"
+
+BOARD_TITLE_SHORT = DEFAULT_BOARD_TITLES[0]
+BOARD_TITLE_LONG = DEFAULT_BOARD_TITLES[2]
+
+
+def _end_of_utc_day(d: date) -> datetime:
+    return datetime(d.year, d.month, d.day, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+
+async def get_board(
+    db: AsyncSession, board_id: int, owner_id: int | None = None
+) -> Board | None:
+    q = select(Board).where(Board.id == board_id)
+    if owner_id is not None:
+        q = q.where(Board.owner_id == owner_id)
+    result = await db.execute(q)
+    return result.scalars().first()
 
 
 async def create_board(db: AsyncSession, title: str, owner_id: int):
@@ -121,8 +140,15 @@ async def _get_card_with_column(db: AsyncSession, card_id: int) -> Card | None:
 
 
 async def create_goal(
-    db: AsyncSession, text: str, board_id: int, owner_id: int | None = None
+    db: AsyncSession,
+    text: str,
+    board_id: int,
+    owner_id: int | None = None,
+    due_date: date | None = None,
 ) -> Card | None:
+    board = await get_board(db, board_id, owner_id=owner_id)
+    if board is None:
+        return None
     column = await get_todo_column(db, board_id, owner_id=owner_id)
     if not column:
         return None
@@ -131,7 +157,15 @@ async def create_goal(
     )
     max_order = max_order_result.scalars().first() or 0
 
-    card = Card(text=text, order=max_order + 1, column_id=column.id)
+    due_at: datetime | None = None
+    if board.title == BOARD_TITLE_SHORT:
+        due_at = _end_of_utc_day(datetime.now(timezone.utc).date())
+    elif board.title == BOARD_TITLE_LONG:
+        if due_date is None:
+            return None
+        due_at = _end_of_utc_day(due_date)
+
+    card = Card(text=text, order=max_order + 1, column_id=column.id, due_at=due_at)
     db.add(card)
     await db.commit()
     return await _get_card_with_column(db, card.id)

--- a/backend/src/models/card.py
+++ b/backend/src/models/card.py
@@ -11,6 +11,7 @@ class Card(Base):
     text = Column(Text)
     order = Column(Integer)
     column_id = Column(Integer, ForeignKey("columns.id"))
+    due_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     column = relationship("BoardColumn", back_populates="cards")
 

--- a/backend/src/routers/boards.py
+++ b/backend/src/routers/boards.py
@@ -3,11 +3,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.deps import get_current_user
 from src.crud.board import (
+    BOARD_TITLE_LONG,
     create_board,
     create_goal,
     delete_board,
     delete_goal,
     ensure_default_boards,
+    get_board,
     list_goals,
     update_goal,
 )
@@ -50,8 +52,21 @@ async def create_goal_endpoint(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    board = await get_board(db, board_id, owner_id=current_user.id)
+    if board is None:
+        raise HTTPException(status_code=404, detail="Board not found")
+    if board.title == BOARD_TITLE_LONG and payload.due_date is None:
+        raise HTTPException(
+            status_code=400,
+            detail="due_date is required for long-term goals",
+        )
+
     goal = await create_goal(
-        db, text=payload.text, board_id=board_id, owner_id=current_user.id
+        db,
+        text=payload.text,
+        board_id=board_id,
+        owner_id=current_user.id,
+        due_date=payload.due_date,
     )
     if not goal:
         raise HTTPException(status_code=404, detail="Board not found")

--- a/backend/src/schemas/board.py
+++ b/backend/src/schemas/board.py
@@ -1,3 +1,5 @@
+from datetime import date, datetime
+
 from pydantic import BaseModel
 
 
@@ -18,7 +20,9 @@ class GoalBase(BaseModel):
 
 
 class GoalCreate(GoalBase):
-    pass
+    """Для доски «Долгосрочные» поле обязательно; для «Краткосрочные» игнорируется."""
+
+    due_date: date | None = None
 
 
 class GoalUpdate(BaseModel):
@@ -29,6 +33,7 @@ class GoalUpdate(BaseModel):
 class GoalOut(GoalBase):
     id: int
     column_title: str = "to do"
+    due_at: datetime | None = None
 
     class Config:
         from_attributes = True

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,8 @@ import { GoalFormModal } from "./components/GoalFormModal";
 import { Header } from "./components/Header";
 import { useAuth } from "./hooks/useAuth";
 import { useBoard } from "./hooks/useBoard";
-import type { Goal } from "./types";
+import { BOARD_TITLE_LONG, type Goal } from "./types";
+const BOARD_TITLE_SHORT = "Краткосрочные";
 
 function BoardScreen() {
   const {
@@ -36,10 +37,14 @@ function BoardScreen() {
     setEditingGoal(null);
   };
 
-  const handleSaveGoal = async (text: string) => {
+  const selectedBoard = boards.find((b) => b.id === selectedBoardId);
+  const showDueDateForNewGoal =
+    editingGoal == null && selectedBoard?.title === BOARD_TITLE_LONG;
+
+  const handleSaveGoal = async (text: string, dueDate?: string) => {
     const ok = editingGoal
       ? await editGoal(editingGoal.id, text)
-      : await addGoal(text);
+      : await addGoal(text, dueDate);
     if (ok) closeGoalForm();
   };
 
@@ -67,6 +72,7 @@ function BoardScreen() {
       {!loading && (
         <Board
           goals={goals}
+          isShortBoard={selectedBoard?.title === BOARD_TITLE_SHORT}
           onEditRequest={(goal) => {
             setEditingGoal(goal);
             setGoalFormOpen(true);
@@ -89,6 +95,7 @@ function BoardScreen() {
         open={goalFormOpen}
         editingGoal={editingGoal}
         saving={saving}
+        showDueDatePicker={showDueDateForNewGoal}
         onClose={closeGoalForm}
         onSave={handleSaveGoal}
       />

--- a/frontend/src/api/boards.ts
+++ b/frontend/src/api/boards.ts
@@ -13,10 +13,17 @@ export const createBoard = (title: string) =>
 export const listGoals = (boardId: number) =>
   apiRequest<Goal[]>(`${API_BASE}/boards/${boardId}/goals`);
 
-export const createGoal = (boardId: number, text: string) =>
+export const createGoal = (
+  boardId: number,
+  text: string,
+  opts?: { dueDate?: string }
+) =>
   apiRequest<Goal>(`${API_BASE}/boards/${boardId}/goals`, {
     method: "POST",
-    body: JSON.stringify({ text }),
+    body: JSON.stringify({
+      text,
+      ...(opts?.dueDate ? { due_date: opts.dueDate } : {}),
+    }),
   });
 
 export const patchGoal = (

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -4,12 +4,19 @@ import type { Goal } from "../types";
 
 type Props = {
   goals: Goal[];
+  isShortBoard: boolean;
   onEditRequest: (goal: Goal) => void;
   onDelete: (goalId: number) => void;
   onMove: (goalId: number, column: string) => void;
 };
 
-export function Board({ goals, onEditRequest, onDelete, onMove }: Props) {
+export function Board({
+  goals,
+  isShortBoard,
+  onEditRequest,
+  onDelete,
+  onMove,
+}: Props) {
   return (
     <div className="board">
       {COLUMNS.map((colTitle) => (
@@ -17,6 +24,7 @@ export function Board({ goals, onEditRequest, onDelete, onMove }: Props) {
           key={colTitle}
           title={colTitle}
           goals={getGoalsForColumn(goals, colTitle)}
+          isShortBoard={isShortBoard}
           onEditRequest={onEditRequest}
           onDelete={onDelete}
           onMove={onMove}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -3,9 +3,32 @@ import type { Goal } from "../types";
 
 const PREVIEW_MAX = 80;
 
+function formatDueShort(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("ru-RU", {
+    day: "numeric",
+    month: "short",
+  });
+}
+
+/** Локальный календарный день: «сегодня» вместо даты для целей до конца текущего дня. */
+function formatDueSticker(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const now = new Date();
+  const sameLocalDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+  if (sameLocalDay) return "сегодня";
+  return `до ${formatDueShort(iso)}`;
+}
+
 type Props = {
   goal: Goal;
   dragging: boolean;
+  isShortBoard: boolean;
   onEditRequest: (goal: Goal) => void;
   onDelete: (goalId: number) => void;
   onDragStart: (goalId: number, e: DragEvent) => void;
@@ -15,6 +38,7 @@ type Props = {
 export function Card({
   goal,
   dragging,
+  isShortBoard,
   onEditRequest,
   onDelete,
   onDragStart,
@@ -43,6 +67,11 @@ export function Card({
     >
       <div className="card-body">
         <span className="card-text">{displayText}</span>
+        {goal.due_at ? (
+          <span className="card-due">
+            {isShortBoard ? "сегодня" : formatDueSticker(goal.due_at)}
+          </span>
+        ) : null}
       </div>
       <div className="card-actions">
         <button

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -6,12 +6,20 @@ import type { ColumnTitle, Goal } from "../types";
 type Props = {
   title: ColumnTitle;
   goals: Goal[];
+  isShortBoard: boolean;
   onEditRequest: (goal: Goal) => void;
   onDelete: (goalId: number) => void;
   onMove: (goalId: number, column: string) => void;
 };
 
-export function Column({ title, goals, onEditRequest, onDelete, onMove }: Props) {
+export function Column({
+  title,
+  goals,
+  isShortBoard,
+  onEditRequest,
+  onDelete,
+  onMove,
+}: Props) {
   const [draggingId, setDraggingId] = useState<number | null>(null);
   const [dragOver, setDragOver] = useState(false);
 
@@ -37,6 +45,7 @@ export function Column({ title, goals, onEditRequest, onDelete, onMove }: Props)
           key={goal.id}
           goal={goal}
           dragging={draggingId === goal.id}
+          isShortBoard={isShortBoard}
           onEditRequest={onEditRequest}
           onDelete={onDelete}
           onDragStart={(id, e) => {

--- a/frontend/src/components/GoalFormModal.tsx
+++ b/frontend/src/components/GoalFormModal.tsx
@@ -1,21 +1,50 @@
 import { useEffect, useState } from "react";
 import type { Goal } from "../types";
 
+function todayLocalISO(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function formatDueRu(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("ru-RU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
 type Props = {
   open: boolean;
   editingGoal: Goal | null;
   saving: boolean;
+  /** Только при создании на доске «Долгосрочные» */
+  showDueDatePicker: boolean;
   onClose: () => void;
-  onSave: (text: string) => Promise<void>;
+  onSave: (text: string, dueDate?: string) => Promise<void>;
 };
 
-export function GoalFormModal({ open, editingGoal, saving, onClose, onSave }: Props) {
+export function GoalFormModal({
+  open,
+  editingGoal,
+  saving,
+  showDueDatePicker,
+  onClose,
+  onSave,
+}: Props) {
   const [text, setText] = useState("");
+  const [dueDate, setDueDate] = useState("");
   const [error, setError] = useState("");
 
   useEffect(() => {
     if (!open) return;
     setText(editingGoal?.text ?? "");
+    setDueDate("");
     setError("");
   }, [editingGoal, open]);
 
@@ -30,17 +59,24 @@ export function GoalFormModal({ open, editingGoal, saving, onClose, onSave }: Pr
 
   if (!open) return null;
 
+  const readOnlyDue = editingGoal?.due_at ?? null;
+
   const handleSave = async () => {
     if (!text.trim()) {
       setError("Описание цели не может быть пустым");
       return;
     }
+    if (showDueDatePicker && !dueDate) {
+      setError("Выберите дату окончания");
+      return;
+    }
     setError("");
-    await onSave(text.trim());
+    await onSave(text.trim(), showDueDatePicker ? dueDate : undefined);
   };
 
   const handleCancel = () => {
     setText("");
+    setDueDate("");
     setError("");
     onClose();
   };
@@ -83,6 +119,26 @@ export function GoalFormModal({ open, editingGoal, saving, onClose, onSave }: Pr
           rows={6}
           autoFocus
         />
+
+        {readOnlyDue ? (
+          <p className="goal-form-due-readonly">
+            Срок: <strong>{formatDueRu(readOnlyDue)}</strong>
+            <span className="goal-form-due-hint"> (изменить нельзя)</span>
+          </p>
+        ) : null}
+
+        {showDueDatePicker ? (
+          <label className="goal-form-date-field">
+            <span className="goal-form-date-label">Дата окончания</span>
+            <input
+              type="date"
+              className="goal-form-date-input"
+              value={dueDate}
+              min={todayLocalISO()}
+              onChange={(e) => setDueDate(e.target.value)}
+            />
+          </label>
+        ) : null}
 
         {error ? <p className="goal-form-error">{error}</p> : null}
 

--- a/frontend/src/hooks/useBoard.ts
+++ b/frontend/src/hooks/useBoard.ts
@@ -12,6 +12,13 @@ function toMessage(e: unknown): string {
   return e instanceof Error ? e.message : "Ошибка";
 }
 
+/** Временно скрыта на фронте; бэкенд и данные доски не трогаем. */
+const BOARD_TITLE_HIDDEN_ON_FRONTEND = "Среднесрочные";
+
+function visibleBoards(boards: Board[]): Board[] {
+  return boards.filter((b) => b.title !== BOARD_TITLE_HIDDEN_ON_FRONTEND);
+}
+
 export function useBoard() {
   const [boards, setBoards] = useState<Board[]>([]);
   const [selectedBoardId, setSelectedBoardId] = useState<number | null>(null);
@@ -27,10 +34,13 @@ export function useBoard() {
       try {
         const boardsData = await listBoards();
         if (cancelled) return;
-        setBoards(boardsData);
+        const shown = visibleBoards(boardsData);
+        setBoards(shown);
 
-        const firstId = boardsData[0]?.id ?? null;
-        setSelectedBoardId(firstId);
+        setSelectedBoardId((current) => {
+          if (current != null && shown.some((b) => b.id === current)) return current;
+          return shown[0]?.id ?? null;
+        });
       } catch (e) {
         if (!cancelled) setError(toMessage(e));
       } finally {
@@ -68,12 +78,16 @@ export function useBoard() {
     };
   }, [selectedBoardId]);
 
-  const addGoal = async (text: string): Promise<boolean> => {
+  const addGoal = async (text: string, dueDate?: string): Promise<boolean> => {
     if (selectedBoardId == null || !text.trim()) return false;
     setSaving(true);
     setError(null);
     try {
-      const created = await createGoal(selectedBoardId, text);
+      const created = await createGoal(
+        selectedBoardId,
+        text,
+        dueDate ? { dueDate } : undefined
+      );
       setGoals((prev) => [...prev, created]);
       return true;
     } catch (e) {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -314,6 +314,55 @@ body {
   box-shadow: 0 0 0 2px rgba(255, 209, 102, 0.4);
 }
 
+.goal-form-due-readonly {
+  margin: 0.75rem 0 0;
+  font-size: 0.875rem;
+  font-family: 'Poppins', sans-serif;
+  color: #4b5563;
+}
+
+.goal-form-due-readonly strong {
+  color: #2d3748;
+}
+
+.goal-form-due-hint {
+  font-weight: 400;
+  color: #9ca3af;
+  font-size: 0.8125rem;
+}
+
+.goal-form-date-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 0.75rem;
+}
+
+.goal-form-date-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  font-family: 'Poppins', sans-serif;
+  color: #2d3748;
+}
+
+.goal-form-date-input {
+  width: 100%;
+  max-width: 12rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+  font-family: 'Poppins', sans-serif;
+  color: #1e293b;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  background: #fff;
+}
+
+.goal-form-date-input:focus {
+  outline: none;
+  border-color: #ffd166;
+  box-shadow: 0 0 0 2px rgba(255, 209, 102, 0.4);
+}
+
 .goal-form-error {
   color: #e53e3e;
   font-size: 0.875rem;
@@ -497,14 +546,22 @@ body {
 
 .card-body {
   display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.35rem;
   min-width: 0;
+  flex: 1;
+}
+
+.card-due {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--muted-foreground);
+  font-family: 'Poppins', sans-serif;
 }
 
 .card-text {
   user-select: none;
-  flex: 1;
   min-width: 0;
   font-size: 13px;
   line-height: 1.4;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7,10 +7,15 @@ export const COLUMN_LABELS: Record<ColumnTitle, string> = {
   done: "Done",
 };
 
+/** Совпадает с названием доски на бэкенде */
+export const BOARD_TITLE_LONG = "Долгосрочные";
+
 export type Goal = {
   id: number;
   text: string;
   column_title: string;
+  /** ISO 8601, конец выбранного дня (UTC) */
+  due_at?: string | null;
 };
 
 export type Board = {


### PR DESCRIPTION
Add due_at support for goals with board-specific creation rules: short-term goals auto-expire at end of day, long-term goals require chosen due date, and due date remains immutable after creation. Update UI to support due-date input and due display, including today label on short-term stickers.

Made-with: Cursor